### PR TITLE
bug fix - preview image generator

### DIFF
--- a/utils/createPreviewCollage.js
+++ b/utils/createPreviewCollage.js
@@ -22,7 +22,7 @@ const saveProjectPreviewImage = async (_data) => {
   // Prepare canvas
   const previewCanvasWidth = thumbWidth * thumbPerRow;
   const previewCanvasHeight =
-    thumbHeight * Math.trunc(_data.length / thumbPerRow);
+    thumbHeight * Math.ceil(_data.length / thumbPerRow);
   // Shout from the mountain tops
   console.log(
     `Preparing a ${previewCanvasWidth}x${previewCanvasHeight} project preview with ${_data.length} thumbnails.`


### PR DESCRIPTION
instead of `Math.trunc()` this PR rounds "up" the preview img canvas height to prevent a collection's final row from being excluded.