### PR TITLE
Added Solana Metaplex metadata format.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,8 @@ const basePath = isLocal ? process.cwd() : path.dirname(process.execPath);
 const { MODE } = require(path.join(basePath, "constants/blend_mode.js"));
 const { NETWORK } = require(path.join(basePath, "constants/network.js"));
 
-const network = NETWORK.eth;
+// const network = NETWORK.eth;
+const network = NETWORK.sol;
 
 // General metadata for Ethereum
 const namePrefix = "Your Collection";
@@ -16,7 +17,6 @@ const baseUri = "ipfs://NewUriToReplace";
 const solanaMetadata = {
   symbol: "YC",
   seller_fee_basis_points: 1000, // Define how much % you want from secondary market sales 1000 = 10%
-  external_url: "https://www.youtube.com/c/hashlipsnft",
   creators: [
     {
       address: "7fXNuer5sbZtaTEPhtJ5g5gNtuyRoKkvxdjEjEnPN4mC",


### PR DESCRIPTION
- After the deletion of line "external url", the metadata json worked for Solana Metaplex.
- The commenting of network.eth and network.sol makes it more obvious that there are two network options.