### PR TITLE
Change name of attribute 'chance' to 'weight'

### DIFF
--- a/utils/rarity.js
+++ b/utils/rarity.js
@@ -25,7 +25,7 @@ layerConfigurations.forEach((config) => {
       // just get name and weight for each element
       let rarityDataElement = {
         trait: element.name,
-        chance: element.weight.toFixed(0),
+        weight: element.weight.toFixed(0),
         occurrence: 0, // initialize at 0
       };
       elementsForLayer.push(rarityDataElement);


### PR DESCRIPTION
'weight' is used elsewhere in the project and more accurately describes the attribute (chance suggests a percentage, whereas the actual chance of occurrence is found by dividing individual weight by total weight * 100)