### PR TITLE
Included rarity of editions that omit a layer

### DIFF
--- a/utils/rarity.js
+++ b/utils/rarity.js
@@ -76,13 +76,13 @@ for (var layer in rarityData) {
     
   }
     if (editionsWithoutLayer > 0){
-    // get chance
+    
     let trait = 'no'+layer;
 
     let chance =
       ((editionsWithoutLayer / editionSize) * 100).toFixed(2);
 
-    // show two decimal places in percent
+    // add occurence to layer rarity
     let occStr =
       `${editionsWithoutLayer} in ${editionSize} editions (${chance} %)`;
       rarityData[layer].push({trait: trait, weight: 'n/a', occurrence:occStr})

--- a/utils/rarity.js
+++ b/utils/rarity.js
@@ -61,7 +61,10 @@ data.forEach((element) => {
 
 // convert occurrences to occurence string
 for (var layer in rarityData) {
+  //initialize to keep track how many editions without layer occur
+  var editionsWithoutLayer = editionSize;
   for (var attribute in rarityData[layer]) {
+    editionsWithoutLayer = editionsWithoutLayer - rarityData[layer][attribute].occurrence
     // get chance
     let chance =
       ((rarityData[layer][attribute].occurrence / editionSize) * 100).toFixed(2);
@@ -69,7 +72,22 @@ for (var layer in rarityData) {
     // show two decimal places in percent
     rarityData[layer][attribute].occurrence =
       `${rarityData[layer][attribute].occurrence} in ${editionSize} editions (${chance} %)`;
+    
+    
   }
+    if (editionsWithoutLayer > 0){
+    // get chance
+    let trait = 'no'+layer;
+
+    let chance =
+      ((editionsWithoutLayer / editionSize) * 100).toFixed(2);
+
+    // show two decimal places in percent
+    let occStr =
+      `${editionsWithoutLayer} in ${editionSize} editions (${chance} %)`;
+      rarityData[layer].push({trait: trait, weight: 'n/a', occurrence:occStr})
+    }
+
 }
 
 // print out rarity data


### PR DESCRIPTION
Updated the rarity functionality to include the occurrence of editions that do not have a certain layer (e.g. if editions were generated with a layer configuration that did not include a certain layer)