### PR TITLE
Fix: renames variable 'nameWithoutWeight' in 'getRarityWeight' functi…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -47,13 +47,11 @@ const buildSetup = () => {
 
 const getRarityWeight = (_str) => {
   let nameWithoutExtension = _str.slice(0, -4);
-  var nameWithoutWeight = Number(
-    nameWithoutExtension.split(rarityDelimiter).pop()
-  );
-  if (isNaN(nameWithoutWeight)) {
-    nameWithoutWeight = 1;
+  var rarityWeight = Number(nameWithoutExtension.split(rarityDelimiter).pop());
+  if (isNaN(rarityWeight)) {
+    rarityWeight = 1;
   }
-  return nameWithoutWeight;
+  return rarityWeight;
 };
 
 const cleanDna = (_str) => {


### PR DESCRIPTION
…on to 'weight'

Trying to understand how the `rarity` is calculated I encounter a "lying" variable name.
The previous  `nameWithoutWeight` variable in the `getRarityWeight` function stores the rarity weight, not the name without the weight. Hope it helps some people to not go crazy when reading the code 😄.

Btw, awesome thanks for this cool repo 🤙