### PR TITLE
chore: changed the metadata for image placeholders to refer edition number

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,7 +146,7 @@ const addMetadata = (_dna, _edition) => {
       description: tempMetadata.description,
       //Added metadata for solana
       seller_fee_basis_points: solanaMetadata.seller_fee_basis_points,
-      image: `image.png`,
+      image: `${_edition}.png`,
       //Added metadata for solana
       external_url: solanaMetadata.external_url,
       edition: _edition,
@@ -155,7 +155,7 @@ const addMetadata = (_dna, _edition) => {
       properties: {
         files: [
           {
-            uri: "image.png",
+            uri: `${_edition}.png`,
             type: "image/png",
           },
         ],


### PR DESCRIPTION
The current way candy-machine operates in terms of arweave uploads is it looks for edition numbers in the image placeholder of each NFT JSON metadata. 

Ref - https://twitter.com/redacted_j/status/1473718957119057923

This is an update to make sure the metadata is adjusted as per the said requirement. 