### PR TITLE
Updated image paths for solana

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const network = NETWORK.eth;
 // General metadata for Ethereum
 const namePrefix = "Your Collection";
 const description = "Remember to replace this description";
-const baseUri = "ipfs://NewUriToReplace";
+const baseUri = "";
 
 const solanaMetadata = {
   symbol: "YC",

--- a/src/main.js
+++ b/src/main.js
@@ -130,7 +130,7 @@ const addMetadata = (_dna, _edition) => {
   let tempMetadata = {
     name: `${namePrefix} #${_edition}`,
     description: description,
-    image: `${baseUri}/${_edition}.png`,
+    image: `${_edition}.png`,
     dna: sha1(_dna),
     edition: _edition,
     date: dateTime,
@@ -146,7 +146,7 @@ const addMetadata = (_dna, _edition) => {
       description: tempMetadata.description,
       //Added metadata for solana
       seller_fee_basis_points: solanaMetadata.seller_fee_basis_points,
-      image: `image.png`,
+      image: `${_edition}}.png`,
       //Added metadata for solana
       external_url: solanaMetadata.external_url,
       edition: _edition,
@@ -155,8 +155,8 @@ const addMetadata = (_dna, _edition) => {
       properties: {
         files: [
           {
-            uri: "image.png",
-            type: "image/png",
+            uri: `${_edition}}.png`,
+            type: `image/${_edition}}.png`,
           },
         ],
         category: "image",


### PR DESCRIPTION
Hey everyone!

If you're running into issues with generating the image metadata in the format of '4.png' instead of the previous 'image/image.png' set up, here are the necessary changes.