### PR TITLE
Underscores in file names are treated as spaces for the JSON output now

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -172,7 +172,7 @@ const addAttributes = (_element) => {
   let selectedElement = _element.layer.selectedElement;
   attributesList.push({
     trait_type: _element.layer.name,
-    value: selectedElement.name,
+    value: selectedElement.name.replace(/_/g, " "),
   });
 };
 


### PR DESCRIPTION
**Was:** 
If a file name was named for example `Black_Test_Test#10.png` it looked like this in the JSON output -> `"value": "Black_Test_Test"`

**Is:** 
If a file name is named `Black_Test_Test#10.png` it now looks this in the JSON output -> `"value": "Black Test Test"`