### PR TITLE
Made some memory optimizations for large collections

### DIFF
--- a/utils/pixelate.js
+++ b/utils/pixelate.js
@@ -66,17 +66,13 @@ const startCreating = async () => {
     console.log("Please generate collection first.");
     return;
   }
-  let loadedImageObjects = [];
-  images.forEach((imgObject) => {
-    loadedImageObjects.push(loadImgData(imgObject));
-  });
-  await Promise.all(loadedImageObjects).then((loadedImageObjectArray) => {
-    loadedImageObjectArray.forEach((loadedImageObject) => {
-      draw(loadedImageObject);
-      saveImage(loadedImageObject);
-      console.log(`Pixelated image: ${loadedImageObject.imgObject.filename}`);
-    });
-  });
+
+  for (const imgObject of images) {
+    const loadedImageObject = await loadImgData(imgObject);
+    draw(loadedImageObject);
+    saveImage(loadedImageObject);
+    console.log(`Pixelated image: ${loadedImageObject.imgObject.filename}`);
+  }
 };
 
 buildSetup();

--- a/utils/preview_gif.js
+++ b/utils/preview_gif.js
@@ -20,7 +20,7 @@ const loadImg = async (_img) => {
 // read image paths
 const imageList = [];
 const rawdata = fs.readdirSync(imageDir).forEach((file) => {
-  imageList.push(loadImg(`${imageDir}/${file}`));
+  imageList.push(file);
 });
 
 const saveProjectPreviewGIF = async (_data) => {
@@ -56,22 +56,23 @@ const saveProjectPreviewGIF = async (_data) => {
     );
     hashlipsGiffer.start();
 
-    await Promise.all(_data).then((renderObjectArray) => {
+    await Promise.all(_data).then(async (fileArray) => {
       // Determin the order of the Images before creating the gif
       if (order == "ASC") {
         // Do nothing
       } else if (order == "DESC") {
-        renderObjectArray.reverse();
+        fileArray.reverse();
       } else if (order == "MIXED") {
-        renderObjectArray = renderObjectArray.sort(() => Math.random() - 0.5);
+        fileArray = fileArray.sort(() => Math.random() - 0.5);
       }
 
       // Reduce the size of the array of Images to the desired amount
       if (parseInt(numberOfImages) > 0) {
-        renderObjectArray = renderObjectArray.slice(0, numberOfImages);
+        fileArray = fileArray.slice(0, numberOfImages);
       }
 
-      renderObjectArray.forEach((renderObject, index) => {
+      await Promise.all(fileArray.map(async (file, index) => {
+        const renderObject = await loadImg(`${imageDir}/${file}`);
         ctx.globalAlpha = 1;
         ctx.globalCompositeOperation = "source-over";
         ctx.drawImage(
@@ -82,7 +83,7 @@ const saveProjectPreviewGIF = async (_data) => {
           previewCanvasHeight
         );
         hashlipsGiffer.add();
-      });
+      }));
     });
     hashlipsGiffer.stop();
   }


### PR DESCRIPTION
When trying to generate pixelated versions of the images or the preview gif, the code previously attempted to load all images into memory and create them in parallel. The drawback of this is that it results in high memory usage, and for large NFT collections, simply crashes the machine. The modifications in this pull request make it so that the pixelate and preview_gif scripts load images sequentially allowing for execution on large sets.