### PR TITLE
update utils/rarity.js: add table format to output

### DIFF
--- a/utils/rarity.js
+++ b/utils/rarity.js
@@ -74,9 +74,17 @@ for (var layer in rarityData) {
 
 // print out rarity data
 for (var layer in rarityData) {
-  console.log(`Trait type: ${layer}`);
-  for (var trait in rarityData[layer]) {
-    console.log(rarityData[layer][trait]);
+  if (process.argv.length <= 2) {
+    console.log(`Trait type: ${layer}`);
+    for (var trait in rarityData[layer]) {
+      console.log(rarityData[layer][trait]);
+    }
+    console.log();
   }
-  console.log();
+  else {
+    if (process.argv[2] == "table") {
+      console.log(`Trait type: ${layer}`);
+      console.table(rarityData[layer]);
+    }
+  }
 }


### PR DESCRIPTION
I found that the actual rarity util output result can be hard to digest. I added the option to show the output in table format using "console.table" instruction. Usage: node utils/rarity.js table:

![image](https://user-images.githubusercontent.com/9491277/149046075-9d4c9b2e-c44c-4f8a-a7c0-59af4b602cca.png)



