### PR TITLE
update main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,7 +146,7 @@ const addMetadata = (_dna, _edition) => {
       description: tempMetadata.description,
       //Added metadata for solana
       seller_fee_basis_points: solanaMetadata.seller_fee_basis_points,
-      image: `image.png`,
+      image: `${_edition}.png`,
       //Added metadata for solana
       external_url: solanaMetadata.external_url,
       edition: _edition,
@@ -155,7 +155,7 @@ const addMetadata = (_dna, _edition) => {
       properties: {
         files: [
           {
-            uri: "image.png",
+            uri:  `${_edition}.png`,
             type: "image/png",
           },
         ],


### PR DESCRIPTION
candy-machine-v2 needs the image name (e.g, 0.png, 1.png ...) instead of "image.png"

Proposed changes 
line 149:  image: `image.png`  ->   image:  `${_edition}.png`

line  158:  image:  `${_edition}.png` ->  image:  `${_edition}.png`