### PR TITLE
Utils/provenance hash an dupload files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,13 @@
   "author": "Daniel Eugene Botha (HashLips)",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.25.0",
     "canvas": "^2.8.0",
+    "crypto": "^1.0.1",
+    "dotenv": "^14.3.0",
+    "form-data": "^4.0.0",
     "gif-encoder-2": "^1.0.5",
+    "path": "^0.12.7",
     "sha1": "^1.1.1"
   }
 }

--- a/utils/createProvenance.js
+++ b/utils/createProvenance.js
@@ -4,23 +4,18 @@ const FormData = require('form-data');
 const path = require('path');
 const basePath = process.cwd();
 
-const finalProof = {
-	provenance: '',
-	collection: [],
-}
-
-let provenanceHash = '';
-let concatedHashString = '';
-
-const hashImages = () => {
+const hashImages = (finalProof, concatedHashString) => {
 	const files = fs.readdirSync(`${basePath}/build/images`);
+	if (!files.length) {
+		return null;
+	}
 	files.sort(function(a, b){
 		return a.split(".")[0] - b.split(".")[0];
 	});
 	let tokenIdCounter = 0;
 	for (const file of files) {
 		const imageHash = createHash('sha256').update(file).digest('hex');
-		concatedHashString += imageHash;
+		concatedHashString.concatedHash += imageHash;
 		const fileName = path.parse(file).name;
 		let jsonFile = fs.readFileSync(`${basePath}/build/json/${fileName}.json`);
 		let metaData = JSON.parse(jsonFile);
@@ -33,19 +28,28 @@ const hashImages = () => {
 		finalProof.collection.push(currentNFT);
 		tokenIdCounter++;
 	}
-	finalProof.provenance = createHash('sha256').update(concatedHashString).digest('hex');;
-	console.log('finalProof.provenance', finalProof.provenance);
-	console.log('concatedHashString', concatedHashString);
-	let concatedHashJSON = fs.readFileSync(`${basePath}/build/json/concatedHash.json`);
-	let parsedConcatedHashJSON = JSON.parse(concatedHashJSON);
-	parsedConcatedHashJSON.concatedHashString = concatedHashString;
-	fs.writeFileSync(`${basePath}/build/json/concatedHash.json`, JSON.stringify(parsedConcatedHashJSON, null, 2));
-	let provenanceHashJSON = fs.readFileSync(`${basePath}/build/json/provenanceHash.json`);
-	let parsedProvenanceHashJSON = JSON.parse(provenanceHashJSON);
-	parsedProvenanceHashJSON.provenance = finalProof.provenance;
-	parsedProvenanceHashJSON.collection.push(finalProof.collection);
-	provenanceHashJSON = JSON.stringify(parsedProvenanceHashJSON);
-	fs.writeFileSync(`${basePath}/build/json/provenanceHash.json`, JSON.stringify(parsedProvenanceHashJSON, null, 2));
+	finalProof.provenance = createHash('sha256').update(concatedHashString.concatedHash).digest('hex');;
 }
 
-hashImages();
+const createProvenanceAndConcatedHashJSON = (finalProof, concatedHashString) => {
+	fs.writeFileSync(`${basePath}/build/json/concatedHash.json`, JSON.stringify(concatedHashString, null, 2));
+	fs.writeFileSync(`${basePath}/build/json/provenanceHash.json`, JSON.stringify(finalProof, null, 2));
+}
+
+const runMain = async () => {
+	const finalProof = {
+		provenance: '',
+		collection: [],
+	}
+	const concatedHashString = {
+		concatedHash: '',
+	};
+
+	if (hashImages(finalProof, concatedHashString) === null) {
+		console.log('No images exist. Please create first your images and json files by running node index.js');
+		return ;
+	}
+	createProvenanceAndConcatedHashJSON(finalProof, concatedHashString);	
+}
+
+runMain();

--- a/utils/createProvenance.js
+++ b/utils/createProvenance.js
@@ -25,7 +25,7 @@ const hashImages = (finalProof, concatedHashString) => {
 		let metaData = JSON.parse(jsonFile);
 		const currentNFT = {
 			tokenId: tokenIdCounter,
-			image: metaData.file_url,
+			image: metaData.image,
 			imageHash: imageHash,
 			traits: metaData.attributes,
 		};
@@ -54,7 +54,7 @@ const runMain = async () => {
 
 	if (hashImages(finalProof, concatedHashString) === null) {
 		console.log('No images exist. Please create first your images and json files by running node index.js');
-		return ;
+		process.exit(0);	
 	}
 	createProvenanceAndConcatedHashJSON(finalProof, concatedHashString);	
 }

--- a/utils/createProvenance.js
+++ b/utils/createProvenance.js
@@ -4,6 +4,10 @@ const FormData = require('form-data');
 const path = require('path');
 const basePath = process.cwd();
 
+/*
+	Here we loop through all generated images, retrieve their filename, hash each image and concat it
+	to concatedHashString.concatedHash, and finally create a an object which to append to finalProof.collection
+*/
 const hashImages = (finalProof, concatedHashString) => {
 	const files = fs.readdirSync(`${basePath}/build/images`);
 	if (!files.length) {
@@ -31,6 +35,9 @@ const hashImages = (finalProof, concatedHashString) => {
 	finalProof.provenance = createHash('sha256').update(concatedHashString.concatedHash).digest('hex');;
 }
 
+/*
+	Here we create the concatedHash.json and provenanceHash.json files in /build/json/
+*/
 const createProvenanceAndConcatedHashJSON = (finalProof, concatedHashString) => {
 	fs.writeFileSync(`${basePath}/build/json/concatedHash.json`, JSON.stringify(concatedHashString, null, 2));
 	fs.writeFileSync(`${basePath}/build/json/provenanceHash.json`, JSON.stringify(finalProof, null, 2));

--- a/utils/createProvenance.js
+++ b/utils/createProvenance.js
@@ -1,0 +1,51 @@
+const { createHash } = require('crypto');
+const fs = require('fs');
+const FormData = require('form-data');
+const path = require('path');
+const basePath = process.cwd();
+
+const finalProof = {
+	provenance: '',
+	collection: [],
+}
+
+let provenanceHash = '';
+let concatedHashString = '';
+
+const hashImages = () => {
+	const files = fs.readdirSync(`${basePath}/build/images`);
+	files.sort(function(a, b){
+		return a.split(".")[0] - b.split(".")[0];
+	});
+	let tokenIdCounter = 0;
+	for (const file of files) {
+		const imageHash = createHash('sha256').update(file).digest('hex');
+		concatedHashString += imageHash;
+		const fileName = path.parse(file).name;
+		let jsonFile = fs.readFileSync(`${basePath}/build/json/${fileName}.json`);
+		let metaData = JSON.parse(jsonFile);
+		const currentNFT = {
+			tokenId: tokenIdCounter,
+			image: metaData.file_url,
+			imageHash: imageHash,
+			traits: metaData.attributes,
+		};
+		finalProof.collection.push(currentNFT);
+		tokenIdCounter++;
+	}
+	finalProof.provenance = createHash('sha256').update(concatedHashString).digest('hex');;
+	console.log('finalProof.provenance', finalProof.provenance);
+	console.log('concatedHashString', concatedHashString);
+	let concatedHashJSON = fs.readFileSync(`${basePath}/build/json/concatedHash.json`);
+	let parsedConcatedHashJSON = JSON.parse(concatedHashJSON);
+	parsedConcatedHashJSON.concatedHashString = concatedHashString;
+	fs.writeFileSync(`${basePath}/build/json/concatedHash.json`, JSON.stringify(parsedConcatedHashJSON, null, 2));
+	let provenanceHashJSON = fs.readFileSync(`${basePath}/build/json/provenanceHash.json`);
+	let parsedProvenanceHashJSON = JSON.parse(provenanceHashJSON);
+	parsedProvenanceHashJSON.provenance = finalProof.provenance;
+	parsedProvenanceHashJSON.collection.push(finalProof.collection);
+	provenanceHashJSON = JSON.stringify(parsedProvenanceHashJSON);
+	fs.writeFileSync(`${basePath}/build/json/provenanceHash.json`, JSON.stringify(parsedProvenanceHashJSON, null, 2));
+}
+
+hashImages();

--- a/utils/uploadImages.js
+++ b/utils/uploadImages.js
@@ -1,0 +1,65 @@
+//imports needed for this function
+const axios = require('axios');
+const fs = require('fs');
+const FormData = require('form-data');
+const dotenv = require('dotenv');
+const path = require('path');
+const basePath = process.cwd();
+dotenv.config();
+
+const pinataApiKey = process.env.API_KEY;
+const pinataSecretApiKey = process.env.API_SECRET;
+
+console.log('pinataApiKey', pinataApiKey);
+console.log('pinataSecretApiKey', pinataSecretApiKey);
+console.log('basePath', basePath);
+
+const pinFileToIPFS = async (pinataApiKey, pinataSecretApiKey) => {
+	const files = fs.readdirSync(`${basePath}/build/images`);
+	files.sort(function(a, b){
+		return a.split(".")[0] - b.split(".")[0];
+	});
+	for (const file of files) {
+		console.log('file', file);
+		const fileName = path.parse(file).name;
+		let jsonFile = fs.readFileSync(`${basePath}/build/json/${fileName}.json`);
+		let metaData = JSON.parse(jsonFile);
+		if(!metaData.file_url.includes('https://')) {
+			const response = await fetchWithRetry(file);
+			console.log('response.data.IpfsHash', response.data.IpfsHash);
+			metaData.file_url = 'ipfs://' + response.data.IpfsHash;
+			fs.writeFileSync(
+				`${basePath}/build/json/${fileName}.json`,
+				JSON.stringify(metaData, null, 2)
+			);
+			console.log(`${file} uploaded & ${fileName}.json updated!`);
+		} else {
+			console.log(`${fileName} already uploaded.`);
+		}
+	}
+};
+
+
+const fetchWithRetry = async (file) => {
+	const formData = new FormData();
+	const fileStream = fs.createReadStream(`${basePath}/build/images/${file}`);
+	formData.append("file", fileStream);
+	const url = `https://api.pinata.cloud/pinning/pinFileToIPFS`;
+
+	console.log('file', file);
+	try {
+		const response = await axios.post(url, formData, {
+			maxBodyLength: 'Infinity', //this is needed to prevent axios from erroring out with large files
+			headers: {
+				'Content-Type': `multipart/form-data; boundary=${formData._boundary}`,
+				pinata_api_key: pinataApiKey,
+				pinata_secret_api_key: pinataSecretApiKey
+			}
+		});
+		return response;
+	} catch (error) {
+		console.log('error', error);
+	}
+}
+
+pinFileToIPFS(pinataApiKey, pinataSecretApiKey);

--- a/utils/uploadImages.js
+++ b/utils/uploadImages.js
@@ -39,7 +39,6 @@ const pinFileToIPFS = async (pinataApiKey, pinataSecretApiKey) => {
 	}
 };
 
-
 const fetchWithRetry = async (file) => {
 	const formData = new FormData();
 	const fileStream = fs.createReadStream(`${basePath}/build/images/${file}`);

--- a/utils/uploadImages.js
+++ b/utils/uploadImages.js
@@ -8,10 +8,9 @@ const basePath = process.cwd();
 dotenv.config();
 
 // Your Pinata API Key
-const pinataApiKey = process.env.API_KEY;
+const pinataApiKey = '';
 // Your Pinata API secret
-const pinataSecretApiKey = process.env.API_SECRET;
-
+const pinataSecretApiKey = '';
 
 /* 
 	Here we upload the images to Pinata, and update the metadata.json file_url with 
@@ -19,6 +18,9 @@ const pinataSecretApiKey = process.env.API_SECRET;
 */
 const pinFileToIPFS = async () => {
 	const files = fs.readdirSync(`${basePath}/build/images`);
+	if (!files.length) {
+		return null;
+	}
 	files.sort(function(a, b){
 		return a.split(".")[0] - b.split(".")[0];
 	});
@@ -26,10 +28,10 @@ const pinFileToIPFS = async () => {
 		const fileName = path.parse(file).name;
 		let jsonFile = fs.readFileSync(`${basePath}/build/json/${fileName}.json`);
 		let metaData = JSON.parse(jsonFile);
-		if(!metaData.file_url.includes('https://')) {
+		if(!metaData.image.includes('https://')) {
 			const response = await uploadToPinata(file);
 			console.log('response.data.IpfsHash', response.data.IpfsHash);
-			metaData.file_url = 'ipfs://' + response.data.IpfsHash;
+			metaData.image = 'ipfs://' + response.data.IpfsHash;
 			fs.writeFileSync(
 				`${basePath}/build/json/${fileName}.json`,
 				JSON.stringify(metaData, null, 2)
@@ -62,4 +64,16 @@ const uploadToPinata = async (file) => {
 	}
 }
 
-pinFileToIPFS();
+const runMain = async () => {
+	try {
+		if (await pinFileToIPFS() === null) {
+			console.log('No images exist. Please create first your images and json files by running node index.js');
+			process.exit(0);	
+		}
+	} catch (error) {
+		console.log('error: ', error);
+		process.exit();	
+	}
+}
+
+runMain();

--- a/utils/uploadImages.js
+++ b/utils/uploadImages.js
@@ -7,25 +7,27 @@ const path = require('path');
 const basePath = process.cwd();
 dotenv.config();
 
+// Your Pinata API Key
 const pinataApiKey = process.env.API_KEY;
+// Your Pinata API secret
 const pinataSecretApiKey = process.env.API_SECRET;
 
-console.log('pinataApiKey', pinataApiKey);
-console.log('pinataSecretApiKey', pinataSecretApiKey);
-console.log('basePath', basePath);
 
-const pinFileToIPFS = async (pinataApiKey, pinataSecretApiKey) => {
+/* 
+	Here we upload the images to Pinata, and update the metadata.json file_url with 
+	the unique CID, instead of having the image folder CID/:id
+*/
+const pinFileToIPFS = async () => {
 	const files = fs.readdirSync(`${basePath}/build/images`);
 	files.sort(function(a, b){
 		return a.split(".")[0] - b.split(".")[0];
 	});
 	for (const file of files) {
-		console.log('file', file);
 		const fileName = path.parse(file).name;
 		let jsonFile = fs.readFileSync(`${basePath}/build/json/${fileName}.json`);
 		let metaData = JSON.parse(jsonFile);
 		if(!metaData.file_url.includes('https://')) {
-			const response = await fetchWithRetry(file);
+			const response = await uploadToPinata(file);
 			console.log('response.data.IpfsHash', response.data.IpfsHash);
 			metaData.file_url = 'ipfs://' + response.data.IpfsHash;
 			fs.writeFileSync(
@@ -39,13 +41,12 @@ const pinFileToIPFS = async (pinataApiKey, pinataSecretApiKey) => {
 	}
 };
 
-const fetchWithRetry = async (file) => {
+const uploadToPinata = async (file) => {
 	const formData = new FormData();
 	const fileStream = fs.createReadStream(`${basePath}/build/images/${file}`);
 	formData.append("file", fileStream);
 	const url = `https://api.pinata.cloud/pinning/pinFileToIPFS`;
 
-	console.log('file', file);
 	try {
 		const response = await axios.post(url, formData, {
 			maxBodyLength: 'Infinity', //this is needed to prevent axios from erroring out with large files
@@ -61,4 +62,4 @@ const fetchWithRetry = async (file) => {
 	}
 }
 
-pinFileToIPFS(pinataApiKey, pinataSecretApiKey);
+pinFileToIPFS();

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,18 @@ are-we-there-yet@^2.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+  dependencies:
+    follow-redirects "^1.14.7"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -89,6 +101,13 @@ color-support@^1.1.2:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -104,6 +123,11 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 debug@4:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
@@ -118,6 +142,11 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -128,10 +157,29 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+dotenv@^14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-14.3.0.tgz#40f537fe90e229d35361c66cf432903e0db49001"
+  integrity sha512-PCTcOQSXVo9FI1dB7AichJXMEvmiGCq0gnCpjfDUc8505uR+2MeLXWe+Ue4PN5UXa2isHSa78sr7L59fk+2mnQ==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -203,6 +251,11 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -226,6 +279,18 @@ make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+mime-types@^2.1.12:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
 
 mimic-response@^2.0.0:
   version "2.1.0"
@@ -309,6 +374,19 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
+process@^0.11.1:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 readable-stream@^3.6.0:
   version "3.6.0"
@@ -434,6 +512,13 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Hey! :)

Hope you don't mind this out-of-the-blue pull request. I create two additional utils functions, which were inspired by this article: https://medium.com/coinmonks/the-elegance-of-the-nft-provenance-hash-solution-823b39f99473#:~:text=Hashing%20the%20Hashes,the%20creation%20of%20the%20hash.&text=We%20call%20this%20final%20hash%20the%20Provenance%20Hash

**createProvenance.js** creates a provenance hash based on the images/jsons that have been generated by by the hashlips art generator, and saves the two additional jsons in build/json/:

1) provenanceHash.json, which is the final proof so to say, and includes the provenance hash + a collection which is json array of objects: 

```
{
"provenance": "",
collection: [
 {
 "tokenId": ,
      "image": "",
      "imageHash": "",
      "traits": [],
 }],
}
```

2) concatedHash.json which contains the concated hash string of all image URIs.


**uploadImages.js** uploads all images to Pinata and updates the according to metadata.image with the unique CID, so the image URI looks like this: 'ipfs://:CID', instead of having ipfs://:CIDofImageFolder/:id

 I find especially the provenance hash as important feature of future NFT collections and should become an essential part to create trust and transparency. 