### PR TITLE
Sharp image compression - Drastic performance increase

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "canvas": "^2.8.0",
     "gif-encoder-2": "^1.0.5",
-    "sha1": "^1.1.1"
+    "sha1": "^1.1.1",
+    "sharp": "^0.29.3"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ const basePath = process.cwd();
 const { NETWORK } = require(`${basePath}/constants/network.js`);
 const fs = require("fs");
 const sha1 = require(`${basePath}/node_modules/sha1`);
+const sharp = require('sharp');
 const { createCanvas, loadImage } = require(`${basePath}/node_modules/canvas`);
 const buildDir = `${basePath}/build`;
 const layersDir = `${basePath}/layers`;
@@ -111,10 +112,7 @@ const layersSetup = (layersOrder) => {
 };
 
 const saveImage = (_editionCount) => {
-  fs.writeFileSync(
-    `${buildDir}/images/${_editionCount}.png`,
-    canvas.toBuffer("image/png")
-  );
+  sharp(canvas.toBuffer('image/png',{ compressionLevel: 0, filters: canvas.PNG_FILTER_NONE })).png({compressionLevel: 4}).toFile( `${buildDir}/images/${_editionCount}.png`);
 };
 
 const genColor = () => {


### PR DESCRIPTION
Current performance tests show a major performance issue with Canvas and image compression when using standard settings.

I found out we can drastically increase performance if we use Sharp library for image compression instead of Canvas and changing canvas parameters to directly write to buffer without image compression.
Current performance test show about a 8-10x increase in speed from it's current version and allows for changing compression parameters while maintaining code integrity.
