### PR TITLE
Skip "None" property when writing metadata

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -173,10 +173,12 @@ const addMetadata = (_dna, _edition) => {
 
 const addAttributes = (_element) => {
   let selectedElement = _element.layer.selectedElement;
-  attributesList.push({
-    trait_type: _element.layer.name,
-    value: selectedElement.name,
-  });
+  if(selectedElement.name.toLowerCase() != "none"){
+    attributesList.push({
+      trait_type: _element.layer.name,
+      value: selectedElement.name,
+    });
+  }
 };
 
 const loadLayerImg = async (_layer) => {


### PR DESCRIPTION
Sometimes we don't need a certain layer, you can add a None.png blank image in the layer folder. I modified the main.js code, when writing the metadata json file, the None attribute will be skipped.
Hopefully this modification will be added to the main release.