### PR TITLE
Modifies DNA_DELIMITER to *

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ ctx.imageSmoothingEnabled = format.smoothing;
 var metadataList = [];
 var attributesList = [];
 var dnaList = new Set();
-const DNA_DELIMITER = "-";
+const DNA_DELIMITER = "*";
 const HashlipsGiffer = require(`${basePath}/modules/HashlipsGiffer.js`);
 
 let hashlipsGiffer = null;
@@ -73,8 +73,8 @@ const getElements = (path) => {
     .readdirSync(path)
     .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
     .map((i, index) => {
-      if (i.includes("-")) {
-        throw new Error(`layer name can not contain dashes, please fix: ${i}`);
+      if (i.includes(DNA_DELIMITER)) {
+        throw new Error(`layer name can not contain the character "${DNA_DELIMITER}"", please fix: ${i}`);
       }
       return {
         id: index,


### PR DESCRIPTION
The `-` is a very common character to use when naming files. Restricting filenames to not include `-` seems odd. I expect a lot of users would want metadata with attributes with a dash, like V-Neck, Hi-Vis, etc.

This PR modifies the `DNA_DELIMITER` to `*` which is a far less common used character in filenames.

Also updated when we should throw an error, which should only be if a filename has the `DNA_DELIMITER`.

Tested and I am able to run my generator just fine.