### PR TITLE
Add process-parallelism for rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,54 @@
 const basePath = process.cwd();
-const { startCreating, buildSetup } = require(`${basePath}/src/main.js`);
+const { numWorkers, batchSize } = require(`${basePath}/src/config.js`);
+const { chooseDnas, createDnas, buildSetup } = require(`${basePath}/src/main.js`);
 
-(() => {
+function chunks(array, size) {
+  return Array.apply(
+    0,
+    new Array(Math.ceil(array.length / size)),
+  ).map((_, index) => array.slice(index * size, (index + 1) * size));
+}
+
+(async () => {
+  const nodeExec = process.argv[0];
   buildSetup();
-  startCreating();
+  const createList = await chooseDnas();
+  if (numWorkers === 1) {
+    await createDnas(createList);
+  } else {
+    const { spawn } = require('child_process');
+    const stream = require('stream');
+
+    const batches = chunks(createList, batchSize);
+    let currentBatch = numWorkers; // first `numWorkers` are kicked manually
+    const runBatch = async (b) => {
+      const child = spawn(nodeExec, [`${basePath}/src/child.js`]);
+
+      child.stdout.pipe(process.stdout);
+      child.stdin.write(JSON.stringify(b));
+      child.stdin.end();
+
+      await new Promise((resolve) => {
+        child.on('close', (code) => {
+          if (code !== 0) {
+            throw new Error(`Child process ended with error code ${code} for batch ${JSON.stringify(b)}`);
+          }
+          resolve();
+        });
+      });
+      // stack depth?
+      if (currentBatch < batches.length) {
+        let idx = currentBatch;
+        currentBatch += 1;
+        await runBatch(batches[idx]);
+      }
+    };
+
+    let workers = [];
+    for (let w = 0; w < numWorkers; ++w) {
+      workers.push(runBatch(batches[w]));
+    }
+
+    await Promise.all(workers);
+  }
 })();

--- a/src/child.js
+++ b/src/child.js
@@ -1,0 +1,10 @@
+const basePath = process.cwd();
+const { createDnas } = require(`${basePath}/src/main.js`);
+
+(() => {
+  const args = process.argv.slice(2);
+  const data = require('fs').readFileSync(process.stdin.fd, 'utf-8');
+
+  const createList = JSON.parse(data);
+  createDnas(createList);
+})();

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,9 @@ const shuffleLayerConfigurations = false;
 
 const debugLogs = false;
 
+const numWorkers = 1;
+const batchSize = 1; // only matters when numWorkers > 1
+
 const format = {
   width: 512,
   height: 512,
@@ -119,4 +122,6 @@ module.exports = {
   solanaMetadata,
   gif,
   preview_gif,
+  numWorkers,
+  batchSize,
 };


### PR DESCRIPTION
When each render is ~3.5-4 seconds, 8 worker threads batch size 1 is ~5-6x speedup.

Possible implementation of https://github.com/HashLips/hashlips_art_engine/issues/571