### PR TITLE
Decimal number weight

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,7 @@ const solanaMetadata = {
 // If you have selected Solana then the collection starts from 0 automatically
 const layerConfigurations = [
   {
-    growEditionSizeTo: 5,
+    growEditionSizeTo: 100,
     layersOrder: [
       { name: "Background" },
       { name: "Eyeball" },

--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,7 @@ const solanaMetadata = {
 // If you have selected Solana then the collection starts from 0 automatically
 const layerConfigurations = [
   {
-    growEditionSizeTo: 100,
+    growEditionSizeTo: 5,
     layersOrder: [
       { name: "Background" },
       { name: "Eyeball" },

--- a/src/main.js
+++ b/src/main.js
@@ -287,7 +287,7 @@ const createDna = (_layers) => {
       totalWeight += element.weight;
     });
     // number between 0 - totalWeight
-    let random = Math.floor(Math.random() * totalWeight);
+    let random = Math.random() * totalWeight;
     for (var i = 0; i < layer.elements.length; i++) {
       // subtract the current weight from the random weight until we reach a sub zero value.
       random -= layer.elements[i].weight;

--- a/utils/rarity.js
+++ b/utils/rarity.js
@@ -25,7 +25,7 @@ layerConfigurations.forEach((config) => {
       // just get name and weight for each element
       let rarityDataElement = {
         trait: element.name,
-        weight: element.weight.toFixed(0),
+        weight: element.weight.toFixed(2),
         occurrence: 0, // initialize at 0
       };
       elementsForLayer.push(rarityDataElement);


### PR DESCRIPTION
**Support assigning decimal numbers to the weight of assets**

The current code doesn't support assigning decimal numbers as weights, because the random value that controls which asset
is selected for the current iteration is being floored (rounded).

I find it very useful to be able to assign decimal weights to assets for the following reasons:

1) If I want to make a single asset more rare than all other assets inside the same layer, it would be easier to just assign a decimal number of less than 1 (e.g 0.2) instead of assigning a greater weight to all other assets (e.g 5).

2) using decimal numbers can, in some cases, be more reflective of the results you want regarding rarity.
For example: if I want Asset 2 to be 50% more frequent than Asset 1 and Asset 3 to be 125% more frequent than Asset 1
the weight assignment will just look like this:

Asset1 (defaults to 1)
Asset2#1.5
Asset3#2.25

I think it looks more clear than assigning much bigger values just to adhere to whole numbers.

I hope you'll find this change useful as well, thanks.
