### PR TITLE
Additions for layer weights, injection layers, layer exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to HashLips 👄
+# Welcome to my fork of the HashLips 👄 Art Engine 
 
 ![](https://github.com/HashLips/hashlips_art_engine/blob/main/logo.png)
 


### PR DESCRIPTION
Adds the following functionality:

- adds an optional custom property to the layers
- adds "class" to layers so that multiple layers can apply to the same trait
- adds injection layers so that a layer may be used to inject custom images or artifacts into the output stream
- adds layer weights based on {n/1000} random number to determine if a layer will be included
- adds mutex array so that the inclusion of a layer can forcibly exclude any number or even all other downstream layers

pretty sure that rarity computations are broken by these changes and I have not bothered to address this.  It seems the original code assumes all layers are included and with these changes that assumption is false.