### PR TITLE
feat: generate custom attributes, closes #1192

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,4 +310,69 @@ Trait type: Top lid
 }
 ```
 
+### Generate custom random attributes
+
+You can add custom random atributers to your collection.
+
+Open the `src/attribute.config.js` file.
+
+Uncomment the lines below and add your custom attributes, from this
+
+```js
+        // {
+        //     //the name of the attribute
+        //     trait_type: "Height",
+        //     //a range of values for the attribute
+        //     minValue: 140,
+        //     maxValue: 200,
+        // },
+        // {
+        //     //the name of the attribute
+        //     trait_type: "Music Genre",
+        //     //a range of values for the attribute
+        //     range: ["Pop", "Punk", "Rock", "Metal", "Disco", "Jazz", "Classical", "Hip Hop", "Reggae", "Blues", "Soul", "Electronic"],
+        // },
+```
+
+to this 
+
+```js
+        {
+            //the name of the attribute
+            trait_type: "Height",
+            //a range of values for the attribute
+            minValue: 140,
+            maxValue: 200,
+        },
+        {
+            //the name of the attribute
+            trait_type: "Music Genre",
+            //a range of values for the attribute
+            range: ["Pop", "Punk", "Rock", "Metal", "Disco", "Jazz", "Classical", "Hip Hop", "Reggae", "Blues", "Soul", "Electronic"],
+        },
+```
+
+The property `trait_type` is the name of the custom attribute. The value of the attribute can be configured in two ways: 
+
+* The property `minValue` and `maxValue`: are the range of values for the attribute.
+* The property `range`: is a list of values for the attribute.
+
+You have to change the value of the `trait_type` property to the name of the attribute you want to add.
+
+Example: 
+
+```js
+        {
+            //the name of the attribute
+            trait_type: "Intelligence",
+            // or trait_type: "Cleanliness",
+            // or trait_type: "Height",
+            // or trait_type: "Music Genre",
+            
+           
+        },
+
+```
+
+
 Hope you create some awesome artworks with this code 👄

--- a/src/attributes.config.js
+++ b/src/attributes.config.js
@@ -1,0 +1,36 @@
+// the value of the attribute can be a range of values or a random number. 
+// To use a range, use the format: range: ["value1", "value2", "value3"]
+// To use a random value, use the format: minValue: 10, maxValue: 100
+const config =  {
+    // add this randomly generated traits to the attributes
+    customAttributes: [
+        // Uncomment to add a random trait to the attributes
+        // {
+        //     //the name of the attribute
+        //     trait_type: "Height",
+        //     //a range of values for the attribute
+        //     minValue: 140,
+        //     maxValue: 200,
+        // },
+        // {
+        //     //the name of the attribute
+        //     trait_type: "Weight",
+        //     //a range of values for the attribute
+        //     minValue: 50,
+        //     maxValue: 100,
+        // },
+        // {
+        //     //the name of the attribute
+        //     trait_type: "Music Genre",
+        //     //a range of values for the attribute
+        //     range: ["Pop", "Punk", "Rock", "Metal", "Disco", "Jazz", "Classical", "Hip Hop", "Reggae", "Blues", "Soul", "Electronic"],
+        // },
+        // {
+        //     trait_type: "Another attribute name",
+        //     minValue: 140,
+        //     maxValue: 200,
+        // },
+    ],
+}
+
+module.exports = config

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,9 @@ const {
   solanaMetadata,
   gif,
 } = require(`${basePath}/src/config.js`);
+
+const attributeConfig = require(`${basePath}/src/attributes.config.js`);
+
 const canvas = createCanvas(format.width, format.height);
 const ctx = canvas.getContext("2d");
 ctx.imageSmoothingEnabled = format.smoothing;
@@ -141,6 +144,9 @@ const addMetadata = (_dna, _edition) => {
     attributes: attributesList,
     compiler: "HashLips Art Engine",
   };
+
+  addCustomMetadata(tempMetadata);
+
   if (network == NETWORK.sol) {
     tempMetadata = {
       //Added metadata for solana
@@ -170,6 +176,24 @@ const addMetadata = (_dna, _edition) => {
   metadataList.push(tempMetadata);
   attributesList = [];
 };
+
+const addCustomMetadata = (tempMetadata) => {
+  attributeConfig.customAttributes.forEach((attribute) => {
+    const { trait_type, range } = attribute;
+    let value;
+    if(range) {
+      value = range[Math.floor(Math.random() * range.length)];
+    }else {
+      value = Math.floor(
+        Math.random() * (attribute.maxValue - attribute.minValue + 1)
+      ) + attribute.minValue
+    }
+    tempMetadata.attributes.push({
+      trait_type,
+      value,
+    });
+  });
+}
 
 const addAttributes = (_element) => {
   let selectedElement = _element.layer.selectedElement;

--- a/src/main.js
+++ b/src/main.js
@@ -181,9 +181,9 @@ const addCustomMetadata = (tempMetadata) => {
   attributeConfig.customAttributes.forEach((attribute) => {
     const { trait_type, range } = attribute;
     let value;
-    if(range) {
+    if (range) {
       value = range[Math.floor(Math.random() * range.length)];
-    }else {
+    } else {
       value = Math.floor(
         Math.random() * (attribute.maxValue - attribute.minValue + 1)
       ) + attribute.minValue


### PR DESCRIPTION

### Generate custom random attributes

You can add custom random atributers to your collection.

Open the `src/attribute.config.js` file.

Uncomment the lines below and add your custom attributes, from this

```js
        // {
        //     //the name of the attribute
        //     trait_type: "Height",
        //     //a range of values for the attribute
        //     minValue: 140,
        //     maxValue: 200,
        // },
        // {
        //     //the name of the attribute
        //     trait_type: "Music Genre",
        //     //a range of values for the attribute
        //     range: ["Pop", "Punk", "Rock", "Metal", "Disco", "Jazz", "Classical", "Hip Hop", "Reggae", "Blues", "Soul", "Electronic"],
        // },
```

to this 

```js
        {
            //the name of the attribute
            trait_type: "Height",
            //a range of values for the attribute
            minValue: 140,
            maxValue: 200,
        },
        {
            //the name of the attribute
            trait_type: "Music Genre",
            //a range of values for the attribute
            range: ["Pop", "Punk", "Rock", "Metal", "Disco", "Jazz", "Classical", "Hip Hop", "Reggae", "Blues", "Soul", "Electronic"],
        },
```

The property `trait_type` is the name of the custom attribute. The value of the attribute can be configured in two ways: 

* The property `minValue` and `maxValue`: are the range of values for the attribute.
* The property `range`: is a list of values for the attribute.

You have to change the value of the `trait_type` property to the name of the attribute you want to add.

Example: 

```js
        {
            //the name of the attribute
            trait_type: "Intelligence",
            // or trait_type: "Cleanliness",
            // or trait_type: "Height",
            // or trait_type: "Music Genre",
            
           
        },

```
