### PR TITLE
use newline as DNA delimiter, update error check about layer names

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ ctx.imageSmoothingEnabled = format.smoothing;
 var metadataList = [];
 var attributesList = [];
 var dnaList = new Set();
-const DNA_DELIMITER = "-";
+const DNA_DELIMITER = "\n";
 const HashlipsGiffer = require(`${basePath}/modules/HashlipsGiffer.js`);
 
 let hashlipsGiffer = null;
@@ -73,8 +73,8 @@ const getElements = (path) => {
     .readdirSync(path)
     .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
     .map((i, index) => {
-      if (i.includes("-")) {
-        throw new Error(`layer name can not contain dashes, please fix: ${i}`);
+      if (i.includes(DNA_DELIMITER)) {
+        throw new Error(`layer name can not contain ${DNA_DELIMITER}, please fix: ${i}`);
       }
       return {
         id: index,


### PR DESCRIPTION
Changed the default `DNA_DELIMITER` to newline, as newlines are unlikely to occur in filenames and it makes the DNA more readable

Updated a check about the layer names containing the DNA delimiter to check the const value rather than hardcoded to -

Fixes #655 